### PR TITLE
Remove "for VMs" from app runtime full

### DIFF
--- a/config/template_variables.yml
+++ b/config/template_variables.yml
@@ -12,7 +12,7 @@ template_variables:
   product_abbr: PDC
   product_short: Developer Console
   ops_manager: Ops Manager
-  app_runtime_full: VMware Tanzu Application Service for VMs
+  app_runtime_full: VMware Tanzu Application Service
   app_runtime_abbr: TAS for VMs
   product_link: <div class="header-item"><a href="https://network.pivotal.io/products/pivotal-cf">Back to Product Page</a></div>
   product_url:


### PR DESCRIPTION
We don't want to suggest that developer console only runs on the BOSH deployed TAS